### PR TITLE
Fix duplicate function definitions in API handlers

### DIFF
--- a/energia-demo/pages/api/analyze-image.ts
+++ b/energia-demo/pages/api/analyze-image.ts
@@ -37,23 +37,8 @@ export default async function handler(
     
     // Generate image hash for cache lookup
     const imageHash = getImageHash(image);
-    
-    // Create a response function with metadata
-    const createResponse = (data: AnalysisResult, source: string, status: string) => {
-      const responseWithMeta: AnalysisResponseWithMeta = {
-        ...data,
-        _meta: {
-          source,
-          status,
-          processTime: Date.now() - startTime
-        }
-      };
-      return responseWithMeta;
-    };
-    
     // Try to get cached response first
     const { status: cacheStatus, data: cachedData } = getCachedResponseWithStatus('analyze', imageHash);
-    
     // Return cached data if valid
     if (cacheStatus === 'hit') {
       console.log(`Cache hit for analyze (${imageHash})`);

--- a/energia-demo/pages/api/generate-future.ts
+++ b/energia-demo/pages/api/generate-future.ts
@@ -37,20 +37,6 @@ export default async function handler(
     
     // Generate image hash for cache lookup
     const imageHash = getImageHash(image);
-    
-    // Create a response function with metadata
-    const createResponse = (data: FutureResult, source: string, status: string) => {
-      const responseWithMeta: FutureResponseWithMeta = {
-        ...data,
-        _meta: {
-          source,
-          status,
-          processTime: Date.now() - startTime
-        }
-      };
-      return responseWithMeta;
-    };
-    
     // Try to get cached response first
     const { status: cacheStatus, data: cachedData } = getCachedResponseWithStatus('future', imageHash);
     


### PR DESCRIPTION
## Summary
- remove arrow function versions of `createResponse` from API handlers
- keep single helper function for responses with metadata

## Testing
- `npx tsc --noEmit` *(fails: Cannot find modules)*