### PR TITLE
Use Web Crypto in browser and remove path module

### DIFF
--- a/energia-demo/lib/demoMode/index.ts
+++ b/energia-demo/lib/demoMode/index.ts
@@ -1,5 +1,19 @@
-import path from 'path';
 import { getImageHash, cacheResponse, prewarmCache, createDemoData, CacheType, getNetworkStatus } from '../cache';
+
+// Minimal path helpers to avoid Node "path" dependency
+function basename(filePath: string, ext?: string): string {
+  const base = filePath.substring(filePath.lastIndexOf('/') + 1);
+  if (ext && base.toLowerCase().endsWith(ext.toLowerCase())) {
+    return base.slice(0, -ext.length);
+  }
+  return base;
+}
+
+function extname(filePath: string): string {
+  const base = filePath.substring(filePath.lastIndexOf('/') + 1);
+  const dot = base.lastIndexOf('.');
+  return dot !== -1 ? base.slice(dot) : '';
+}
 
 // Demo storage keys - must be declared before importing anything that references them
 export const DEMO_MODE_KEY = 'energia_demo_mode';
@@ -729,7 +743,7 @@ export async function initializeDemoMode(): Promise<void> {
       // Fill up active promises if possible
       while (imageQueue.length > 0 && activePromises.length < concurrency) {
         const imagePath = imageQueue.shift()!;
-        const imageId = path.basename(imagePath, path.extname(imagePath));
+        const imageId = basename(imagePath, extname(imagePath));
         
         // Skip already processed images
         if (processedImages.has(imageId)) {
@@ -803,7 +817,7 @@ async function processDemo(imagePath: string, imageId: string): Promise<void> {
   }
   
   // Hash the image for cache lookup
-  const imageHash = getImageHash(base64Data);
+  const imageHash = await getImageHash(base64Data);
   
   // Check if we need to generate a future image version
   let futureImageData = base64Data; // Default to original image
@@ -866,7 +880,7 @@ async function processDemo(imagePath: string, imageId: string): Promise<void> {
   }
   
   // Hash the future image
-  const futureImageHash = getImageHash(futureImageData);
+  const futureImageHash = await getImageHash(futureImageData);
   
   // Prepare data for both analysis and future projections
   const demoImages = [];
@@ -1209,7 +1223,7 @@ export const demoController = {
     
     // Get image ID from the path
     const imagePath = scenarioData.imagePath;
-    const imageId = path.basename(imagePath, path.extname(imagePath));
+    const imageId = basename(imagePath, extname(imagePath));
     
     // Get the future image for this ID
     return getFutureDemoImageById(imageId);
@@ -1222,7 +1236,7 @@ export const demoController = {
     
     // Get image ID from the path
     const imagePath = scenarioData.imagePath;
-    const imageId = path.basename(imagePath, path.extname(imagePath));
+    const imageId = basename(imagePath, extname(imagePath));
     
     return {
       current: getDemoImageById(imageId),

--- a/energia-demo/lib/openai/index.ts
+++ b/energia-demo/lib/openai/index.ts
@@ -155,7 +155,7 @@ export function generateAnnotations(components: OpenAIComponent[]): OpenAIAnnota
 // Function to analyze an image using OpenAI Vision API
 export async function analyzeImage(imageData: string): Promise<AnalysisResult> {
   // Check cache first
-  const imageHash = getImageHash(imageData);
+  const imageHash = await getImageHash(imageData);
   const cachedResult = getCachedResponse('analyze', imageHash);
   
   if (cachedResult) {
@@ -229,7 +229,7 @@ export async function analyzeImage(imageData: string): Promise<AnalysisResult> {
 // Function to generate a future projection using OpenAI
 export async function generateFuture(imageData: string): Promise<FutureResult> {
   // Check cache first
-  const imageHash = getImageHash(imageData);
+  const imageHash = await getImageHash(imageData);
   const cachedResult = getCachedResponse('future', imageHash);
   
   if (cachedResult) {
@@ -319,7 +319,7 @@ export async function generateFuture(imageData: string): Promise<FutureResult> {
 export async function generateFutureImage(imageData: string): Promise<string> {
   try {
     // Check cache first using a hash of the input image plus a "future" prefix
-    const imageHash = getImageHash(`future_${imageData}`);
+    const imageHash = await getImageHash(`future_${imageData}`);
     const cachedResult = getCachedResponse('futureImage', imageHash);
     
     if (cachedResult) {

--- a/energia-demo/pages/api/analyze-image.ts
+++ b/energia-demo/pages/api/analyze-image.ts
@@ -36,7 +36,7 @@ export default async function handler(
     const networkStatus = getNetworkStatus();
     
     // Generate image hash for cache lookup
-    const imageHash = getImageHash(image);
+    const imageHash = await getImageHash(image);
     
     // Create a response function with metadata
     const createResponse = (data: AnalysisResult, source: string, status: string) => {

--- a/energia-demo/pages/api/generate-future.ts
+++ b/energia-demo/pages/api/generate-future.ts
@@ -36,7 +36,7 @@ export default async function handler(
     const networkStatus = getNetworkStatus();
     
     // Generate image hash for cache lookup
-    const imageHash = getImageHash(image);
+    const imageHash = await getImageHash(image);
     
     // Create a response function with metadata
     const createResponse = (data: FutureResult, source: string, status: string) => {


### PR DESCRIPTION
## Summary
- support async hashing via `crypto.subtle` when running in the browser
- remove Node `path` dependency from demo mode with lightweight helpers
- update cache and openai modules for async hash
- update API routes to await new hash helper

## Testing
- `npm run lint` *(fails: `next` not found)*